### PR TITLE
[CI] Use macOS 15 X64 and ARM64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15, macos-15-intel]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/formula/zsv.rb
+++ b/formula/zsv.rb
@@ -1,27 +1,27 @@
 class Zsv < Formula
-  desc "zsv+lib: world's fastest (simd) CSV parser, with an extensible CLI"
-  homepage 'https://github.com/liquidaty/zsv'
-  head 'https://github.com/liquidaty/zsv.git', branch: 'main'
-  license 'MIT'
+  desc "zsv: tabular data swiss-army knife CLI"
+  homepage "https://github.com/liquidaty/zsv"
+  license "MIT"
+  head "https://github.com/liquidaty/zsv.git", branch: "main"
 
-  AMD64_URL = 'https://github.com/liquidaty/zsv/releases/download/v0.4.4-alpha/zsv-0.4.4-alpha-amd64-macosx-gcc.tar.gz'
-  AMD64_HASH = '1818002d815a1f2dde11adca369fa1912a93dfb0732e570fa269320526f10846'
+  AMD64_URL = "https://github.com/liquidaty/zsv/releases/download/v0.4.4-alpha/zsv-0.4.4-alpha-amd64-macosx-gcc.tar.gz"
+  AMD64_HASH = "1818002d815a1f2dde11adca369fa1912a93dfb0732e570fa269320526f10846"
 
-  ARM64_URL = 'https://github.com/liquidaty/zsv/releases/download/v0.4.4-alpha/zsv-0.4.4-alpha-arm64-macosx-gcc.tar.gz'
-  ARM64_HASH = '3683fccfacf3db260b3c3b77ddcc571a480ff84a16328fd9c96d1d0b6a366709'
+  ARM64_URL = "https://github.com/liquidaty/zsv/releases/download/v0.4.4-alpha/zsv-0.4.4-alpha-arm64-macosx-gcc.tar.gz"
+  ARM64_HASH = "3683fccfacf3db260b3c3b77ddcc571a480ff84a16328fd9c96d1d0b6a366709"
 
   if OS.mac?
     if Hardware::CPU.intel?
-      url "#{AMD64_URL}"
-      sha256 "#{AMD64_HASH}"
+      url AMD64_URL
+      sha256 AMD64_HASH
     elsif Hardware::CPU.arm?
-      url "#{ARM64_URL}"
-      sha256 "#{ARM64_HASH}"
+      url ARM64_URL
+      sha256 ARM64_HASH
     end
   end
 
   def install
-    bin.install 'bin/zsv'
+    bin.install "bin/zsv"
   end
 
   test do


### PR DESCRIPTION
Related: https://github.com/liquidaty/zsv/issues/403

- Use `macos-15-intel` (X64) and `macos-15` (ARM64) runners
- Minor cleanup and update of formula

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>